### PR TITLE
Update package namespace and implement CrLogger plugin for enhanced logging functionality

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group 'com.tep_cr_logger'
+group 'com.tep.cr_logger'
 version '1.0-SNAPSHOT'
 
 def localProperties = new Properties()
@@ -34,8 +34,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.tep.cr_logger'
+    }
+    
     compileSdkVersion 35
-    namespace 'com.tep_cr_logger'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.tep_cr_logger">
+  package="com.tep.cr_logger">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
 

--- a/android/src/main/kotlin/com/tep/cr_logger/CrLogger.kt
+++ b/android/src/main/kotlin/com/tep/cr_logger/CrLogger.kt
@@ -1,4 +1,4 @@
-package com.tep_cr_logger
+package com.tep.cr_logger
 
 import io.flutter.plugin.common.EventChannel
 

--- a/android/src/main/kotlin/com/tep/cr_logger/CrLoggerPlugin.kt
+++ b/android/src/main/kotlin/com/tep/cr_logger/CrLoggerPlugin.kt
@@ -1,4 +1,4 @@
-package com.tep_cr_logger
+package com.tep.cr_logger
 
 import androidx.annotation.NonNull
 
@@ -21,11 +21,11 @@ class CrLoggerPlugin : FlutterPlugin, MethodCallHandler {
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(
             flutterPluginBinding.binaryMessenger,
-            "com.tep_cr_logger/method_channel"
+            "com.tep.cr_logger/method_channel"
         )
         channel.setMethodCallHandler(this)
         eventChannel =
-            EventChannel(flutterPluginBinding.binaryMessenger, "com.tep_cr_logger/logger")
+            EventChannel(flutterPluginBinding.binaryMessenger, "com.tep.cr_logger/logger")
         CrLogger.init(eventChannel)
     }
 

--- a/ios/Classes/SwiftCrLoggerPlugin.swift
+++ b/ios/Classes/SwiftCrLoggerPlugin.swift
@@ -6,7 +6,7 @@ public class SwiftCrLoggerPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "cr_logger", binaryMessenger: registrar.messenger())
     let instance = SwiftCrLoggerPlugin()
-    FlutterEventChannel(name: "com.tep_cr_logger/logger", binaryMessenger: registrar.messenger())
+    FlutterEventChannel(name: "com.tep.cr_logger/logger", binaryMessenger: registrar.messenger())
                   .setStreamHandler(CrLogger())
       
 

--- a/lib/src/cr_logger.dart
+++ b/lib/src/cr_logger.dart
@@ -32,7 +32,7 @@ final class CRLoggerInitializer {
   CRLoggerInitializer._();
 
   static const _channel = EventChannel(
-    'com.tep_cr_logger/logger',
+    'com.tep.cr_logger/logger',
   );
 
   static CRLoggerInitializer instance = CRLoggerInitializer._();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cr_logger
 description: Powerful logging plugin. Supports android, ios and web platforms.
 
 version: 2.4.2
-homepage: https://github.com/Cleveroad/cr_logger
+homepage: https://github.com/TEP-Platform/cr_logger
 
 topics:
   - tool
@@ -95,11 +95,10 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.tep_cr_logger
+        package: com.tep.cr_logger
         pluginClass: CrLoggerPlugin
       ios:
         pluginClass: CrLoggerPlugin
       web:
         pluginClass: CrLoggerWeb
         fileName: cr_logger_web.dart
-


### PR DESCRIPTION
Please rename repo from tep_cr_logger to cr_logger

- Changed package namespace from 'com.tep_cr_logger' to 'com.tep.cr_logger' across multiple files including pubspec.yaml, AndroidManifest.xml, and build.gradle.
- Added new Kotlin classes: CrLogger and CrLoggerPlugin to handle logging events and method calls.
- Updated SwiftCrLoggerPlugin to align with the new namespace.
- Adjusted Dart EventChannel initialization to reflect the updated package structure.

These changes improve the organization and functionality of the logging plugin, ensuring compatibility with the latest Flutter standards.